### PR TITLE
Upgrade derive_more to 0.99.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,16 +26,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 into-regex = ["either", "regex"]
 
 [dependencies]
-derive_more = { version = "0.99.16", features = ["as_ref", "deref", "deref_mut", "display", "error", "from", "into"], default_features = false }
+derive_more = { version = "0.99.17", features = ["as_ref", "deref", "deref_mut", "display", "error", "from", "into"], default_features = false }
 nom = "7.0"
 nom_locate = "4.0"
 
 # "into-regex" feature dependencies
 either = { version = "1.6", optional = true }
 regex = { version = "1.5", optional = true }
-
-# TODO: Remove once `derive_more` 0.99.17 is released.
-syn = "1.0.81"
 
 [workspace]
 members = ["fuzz"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,9 +103,6 @@ mod combinator;
 pub mod expand;
 pub mod parse;
 
-// TODO: Remove once `derive_more` 0.99.17 is released.
-use syn as _;
-
 #[doc(inline)]
 pub use self::ast::{
     Alternation, Alternative, Expression, Optional, Parameter,


### PR DESCRIPTION
Resolves #3

## Synopsis

For now we have to depend on `syn` manually. 




## Solution

Upgrade to `derive_more` to `v0.99.17` to avoid this. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests