### PR TITLE
Fix `float` parameter `regex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,17 @@ All user visible changes to `cucumber-expressions` crate will be documented in t
 
 
 
-## [0.1.2] · 2022-??-??
+## [0.1.2] · 2022-01-??
 [0.1.2]: /../../tree/v0.1.2
 
 [Diff](/../../compare/v0.1.1...v0.1.2) | [Milestone](/../../milestone/3)
 
 ### Fixed
 
-- `float` parameter [`Regex`]. ([#6])
+- Unsupported lookaheads in `float` parameter's [`Regex`]. ([#6], [cucumber-rs/cucumber#197])
 
-[#5]: /../../pull/6
+[#6]: /../../pull/6
+[cucumber-rs/cucumber#197]: https://github.com/cucumber-rs/cucumber/issues/197
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `cucumber-expressions` crate will be documented in t
 
 
 
+## [0.1.2] · 2022-??-??
+[0.1.2]: /../../tree/v0.1.2
+
+[Diff](/../../compare/v0.1.1...v0.1.2) | [Milestone](/../../milestone/3)
+
+### Fixed
+
+- `float` parameter [`Regex`]. ([#6])
+
+[#5]: /../../pull/6
+
+
+
+
 ## [0.1.1] · 2021-11-29
 [0.1.1]: /../../tree/v0.1.1
 

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -417,19 +417,19 @@ where
             Left(r#"((?:-?\d+)|(?:\d+))"#.chars().map(Ok))
         } else if eq(&self.0, "float") {
             // Regex in other implementations has lookaheads. As `regex` crate
-            // doesn't support them, we use f32/f64 grammar:
+            // doesn't support them, we use `f32`/`f64` grammar instead:
             // https://doc.rust-lang.org/stable/std/primitive.f64.html#grammar
             // Provided grammar is a superset of the original one:
-            // - supports 'e' as exponent in addition to 'E'
-            // - supports trailing comma: '1.'
-            // - supports 'inf' and 'NaN'
+            // - supports `e` as exponent in addition to `E`
+            // - supports trailing comma: `1.`
+            // - supports `inf` and `NaN`
             Left(
-                "([+-]?(?:\
-                  inf\
-                  |NaN\
-                  |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?))"
-                    .chars()
-                    .map(Ok),
+                "([+-]?(?:inf\
+                         |NaN\
+                         |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?\
+                       ))"
+                .chars()
+                .map(Ok),
             )
         } else if eq(&self.0, "word") {
             Left(r#"([^\s]+)"#.chars().map(Ok))
@@ -658,10 +658,10 @@ mod spec {
 
         assert_eq!(
             expr.as_str(),
-            "^([+-]?(?:\
-               inf\
-               |NaN\
-               |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?))$",
+            "([+-]?(?:inf\
+                     |NaN\
+                     |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?\
+                   ))",
         );
         assert!(expr.is_match("+1"));
         assert!(expr.is_match(".1"));

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -416,8 +416,18 @@ where
         if eq(&self.0, "int") {
             Left(r#"((?:-?\d+)|(?:\d+))"#.chars().map(Ok))
         } else if eq(&self.0, "float") {
+            // Regex in other implementations has lookaheads. As `regex` crate
+            // doesn't support them, we use f32/f64 grammar:
+            // https://doc.rust-lang.org/stable/std/primitive.f64.html#grammar
+            // Provided grammar is a superset of the original one:
+            // - supports 'e' as exponent in addition to 'E'
+            // - supports trailing comma: '1.'
+            // - supports 'inf' and 'NaN'
             Left(
-                r#"((?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+-]?\d+)?)"#
+                "([+-]?(?:\
+                  inf\
+                  |NaN\
+                  |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?))"
                     .chars()
                     .map(Ok),
             )
@@ -592,6 +602,11 @@ mod spec {
             .unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^(?:a|b) (?:c|d|e)$");
+        assert!(expr.is_match("a c"));
+        assert!(expr.is_match("b e"));
+        assert!(!expr.is_match("c e"));
+        assert!(!expr.is_match("a"));
+        assert!(!expr.is_match("a "));
     }
 
     #[test]
@@ -600,14 +615,17 @@ mod spec {
             Expression::regex("").unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^$");
+        assert!(expr.is_match(""));
+        assert!(!expr.is_match("a"));
     }
 
     #[test]
     fn escape_regex_characters() {
-        let expr = Expression::regex(r"^$[]\(\){}\\.|?*+")
+        let expr = Expression::regex(r"^$[]\()\{}\\.|?*+")
             .unwrap_or_else(|e| panic!("failed: {}", e));
 
-        assert_eq!(expr.as_str(), r"^\^\$\[\]\(\)(.*)\\\.\|\?\*\+$");
+        assert_eq!(expr.as_str(), r"^\^\$\[\]\(\)\{\}\\\.\|\?\*\+$");
+        assert!(expr.is_match("^$[](){}\\.|?*+"));
     }
 
     #[test]
@@ -616,14 +634,80 @@ mod spec {
             .unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^(?:a)?$");
+        assert!(expr.is_match(""));
+        assert!(expr.is_match("a"));
+        assert!(!expr.is_match("b"));
     }
 
     #[test]
-    fn parameter() {
+    fn parameter_int() {
         let expr = Expression::regex("{int}")
             .unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^((?:-?\\d+)|(?:\\d+))$");
+        assert!(expr.is_match("123"));
+        assert!(expr.is_match("-123"));
+        assert!(!expr.is_match("+123"));
+        assert!(!expr.is_match("123."));
+    }
+
+    #[test]
+    fn parameter_float() {
+        let expr = Expression::regex("{float}")
+            .unwrap_or_else(|e| panic!("failed: {}", e));
+
+        assert_eq!(
+            expr.as_str(),
+            "^([+-]?(?:\
+               inf\
+               |NaN\
+               |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?))$",
+        );
+        assert!(expr.is_match("+1"));
+        assert!(expr.is_match(".1"));
+        assert!(expr.is_match("-.1"));
+        assert!(expr.is_match("-1."));
+        assert!(expr.is_match("-1.1E+1"));
+        assert!(expr.is_match("-inf"));
+        assert!(expr.is_match("NaN"));
+    }
+
+    #[test]
+    fn parameter_word() {
+        let expr = Expression::regex("{word}")
+            .unwrap_or_else(|e| panic!("failed: {}", e));
+
+        assert_eq!(expr.as_str(), "^([^\\s]+)$");
+        assert!(expr.is_match("test"));
+        assert!(expr.is_match("\"test\""));
+        assert!(!expr.is_match("with space"));
+    }
+
+    #[test]
+    fn parameter_string() {
+        let expr = Expression::regex("{string}")
+            .unwrap_or_else(|e| panic!("failed: {}", e));
+
+        assert_eq!(
+            expr.as_str(),
+            r#"^("(?:[^"\\]*(?:\\.[^"\\]*)*)"|'(?:[^'\\]*(?:\\.[^'\\]*)*)')$"#,
+        );
+        assert!(expr.is_match("\"\""));
+        assert!(expr.is_match("''"));
+        assert!(expr.is_match("'with \"'"));
+        assert!(expr.is_match("\"with '\""));
+        assert!(expr.is_match("\"with \\\" escaped\""));
+        assert!(expr.is_match("'with \\' escaped'"));
+        assert!(!expr.is_match("word"));
+    }
+
+    #[test]
+    fn parameter_all() {
+        let expr =
+            Expression::regex("{}").unwrap_or_else(|e| panic!("failed: {}", e));
+
+        assert_eq!(expr.as_str(), "^(.*)$");
+        assert!(expr.is_match("anything matches"));
     }
 
     #[test]
@@ -632,6 +716,9 @@ mod spec {
             Expression::regex("a").unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^a$");
+        assert!(expr.is_match("a"));
+        assert!(!expr.is_match("b"));
+        assert!(!expr.is_match("ab"));
     }
 
     #[allow(clippy::non_ascii_literal)]
@@ -641,6 +728,9 @@ mod spec {
             .unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^Привет, Мир(?:ы)?!$");
+        assert!(expr.is_match("Привет, Мир!"));
+        assert!(expr.is_match("Привет, Миры!"));
+        assert!(!expr.is_match("Hello world"));
     }
 
     #[test]

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -658,10 +658,10 @@ mod spec {
 
         assert_eq!(
             expr.as_str(),
-            "([+-]?(?:inf\
-                     |NaN\
-                     |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?\
-                   ))",
+            "^([+-]?(?:inf\
+                      |NaN\
+                      |(?:\\d+|\\d+\\.\\d*|\\d*\\.\\d+)(?:[eE][+-]?\\d+)?\
+                    ))$",
         );
         assert!(expr.is_match("+1"));
         assert!(expr.is_match(".1"));


### PR DESCRIPTION
Resolves https://github.com/cucumber-rs/cucumber/issues/197

## Synopsis

`float` parameter `regex` uses lookaheads, which aren't supported by `regex` crate.




## Solution

Use [Rust f32/f64 grammar](https://doc.rust-lang.org/stable/std/primitive.f64.html#grammar), which is superset of the original one. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [ ] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests