### PR TITLE
Add special naming for every regex capture group in `Parameter` (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All user visible changes to `cucumber-expressions` crate will be documented in t
 ### Changed
 
 - Add [`id` field to the `Parameter`][id-param-field] AST struct. ([#8], [#7])
-- Add `string_<id>` name to `string` parameter [`Regex`] capture groups. ([#8], [#7])
+- Support capturing groups inside `Parameter` regex. ([#8], [#7])
 
 [#7]: /../../issues/7
 [#8]: /../../pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All user visible changes to `cucumber-expressions` crate will be documented in t
 
 
 
+## [0.2.0] · 2022-??-??
+[0.2.0]: /../../tree/v0.2.0
+
+[Diff](/../../compare/v0.1.2...v0.2.0) | [Milestone](/../../milestone/4)
+
+### Changed
+
+- Add [`id` field to the `Parameter`][id-param-field] AST struct. ([#8], [#7])
+- Add `string_<id>` name to `string` parameter [`Regex`] capture groups. ([#8], [#7])
+
+[#7]: /../../issues/7
+[#8]: /../../pull/8
+[id-param-field]: https://docs.rs/cucumber-expressions/latest/cucumber_expressions/struct.Parameter.html#structfield.id
+
+
+
+
 ## [0.1.2] · 2022-01-11
 [0.1.2]: /../../tree/v0.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,16 @@ All user visible changes to `cucumber-expressions` crate will be documented in t
 
 [Diff](/../../compare/v0.1.2...v0.2.0) | [Milestone](/../../milestone/4)
 
-### Changed
+### BC Breaks
 
-- Add [`id` field to the `Parameter`][id-param-field] AST struct. ([#8], [#7])
-- Support capturing groups inside `Parameter` regex. ([#8], [#7])
+- Added `id` field to `Parameter` AST struct. ([#8], [#7])
+
+### Added
+
+- Support of capturing groups inside `Parameter` regex. ([#8], [#7])
 
 [#7]: /../../issues/7
 [#8]: /../../pull/8
-[id-param-field]: https://docs.rs/cucumber-expressions/latest/cucumber_expressions/struct.Parameter.html#structfield.id
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Enables ability to expand AST into regex.
-into-regex = ["either", "regex"]
+into-regex = ["either", "regex", "regex-syntax"]
 
 [dependencies]
 derive_more = { version = "0.99.17", features = ["as_ref", "deref", "deref_mut", "display", "error", "from", "into"], default_features = false }
@@ -33,6 +33,7 @@ nom_locate = "4.0"
 # "into-regex" feature dependencies
 either = { version = "1.6", optional = true }
 regex = { version = "1.5", optional = true }
+regex-syntax = { version = "0.6", optional = true }
 
 [workspace]
 members = ["fuzz"]

--- a/fuzz/fuzz_targets/parameter.rs
+++ b/fuzz/fuzz_targets/parameter.rs
@@ -4,5 +4,5 @@ use cucumber_expressions::parse;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &str| {
-    let _ = parse::parameter(data);
+    let _ = parse::parameter(data, &mut 0);
 });

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -170,4 +170,13 @@ pub struct Optional<Input>(pub Input);
 ///
 /// [0]: crate#grammar
 #[derive(AsRef, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialEq)]
-pub struct Parameter<Input>(pub Input);
+pub struct Parameter<Input> {
+    /// Inner `Input`.
+    #[deref]
+    #[deref_mut]
+    pub input: Input,
+
+    /// ID of the [`Parameter`].
+    #[as_ref(ignore)]
+    pub id: usize,
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -176,7 +176,7 @@ pub struct Parameter<Input> {
     #[deref_mut]
     pub input: Input,
 
-    /// ID of the [`Parameter`].
+    /// Unique ID of this [`Parameter`] in the parsed [`Expression`].
     #[as_ref(ignore)]
     pub id: usize,
 }

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -541,7 +541,8 @@ pub struct OwnedChars {
 
 impl OwnedChars {
     /// Creates a new [`OwnedChars`] [`Iterator`].
-    pub fn new(str: String) -> Self {
+    #[must_use]
+    pub const fn new(str: String) -> Self {
         Self { str, cur: 0 }
     }
 }

--- a/src/expand/mod.rs
+++ b/src/expand/mod.rs
@@ -165,12 +165,13 @@ where
     Input: fmt::Display,
 {
     /// [`Parameter`] not found.
-    #[display(fmt = "Parameter '{}' not found.", _0)]
+    #[display(fmt = "Parameter `{}` not found.", _0)]
     NotFound(Input),
 
     /// Failed to rename [`Regex`] capturing group.
     #[display(
-        fmt = "Failed to rename groups in regex '{}' of parameter '{}': {}",
+        fmt = "Failed to rename capturing groups in regex `{}` of \
+               parameter `{}`: {}",
         re,
         parameter,
         err
@@ -182,7 +183,7 @@ where
         /// [`Regex`] of the [`Parameter`].
         re: String,
 
-        /// [`Error`] of parsing [`Regex`].
+        /// [`Error`] of parsing the [`Regex`] with renamed capturing groups.
         ///
         /// [`Error`]: regex_syntax::Error
         err: regex_syntax::Error,
@@ -541,7 +542,9 @@ where
     }
 }
 
-/// Like [`str::Chars`], but owns [`String`].
+// TODO: Make private, once TAIT stabilized:
+//       https://github.com/rust-lang/rust/issues/63063
+/// Like [`str::Chars`] [`Iterator`], but owns its [`String`].
 #[derive(Clone, Debug)]
 pub struct OwnedChars {
     /// Iterated [`String`].
@@ -756,8 +759,8 @@ mod spec {
         assert_eq!(
             expr.as_str(),
             "^(?:\
-                \"(?P<__0_0>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|\
-                '(?P<__0_1>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'\
+                \"(?P<__0_0>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\
+                |'(?P<__0_1>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'\
              )$",
         );
         assert!(expr.is_match("\"\""));
@@ -778,11 +781,11 @@ mod spec {
         assert_eq!(
             expr.as_str(),
             "^(?:\
-                \"(?P<__0_0>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|\
-                '(?P<__0_1>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'\
+                \"(?P<__0_0>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\
+                |'(?P<__0_1>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'\
               ) (?:\
-                \"(?P<__1_0>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|\
-                '(?P<__1_1>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'\
+                \"(?P<__1_0>[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"\
+                |'(?P<__1_1>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'\
               )$",
         );
         assert!(expr.is_match("\"\" ''"));

--- a/src/expand/parameters.rs
+++ b/src/expand/parameters.rs
@@ -302,7 +302,7 @@ type WithParsIter<I, P> = Either<
 
 /// Helper methods to work with [`Regex`]es [`Hir`].
 ///
-/// [`Hir`]: hir::Hir
+/// [`Hir`]: regex_syntax::hir::Hir
 /// [`Regex`]: regex::Regex
 mod regex_hir {
     use std::mem;

--- a/src/expand/parameters.rs
+++ b/src/expand/parameters.rs
@@ -12,23 +12,25 @@
 //!
 //! [1]: https://github.com/cucumber/cucumber-expressions#custom-parameter-types
 
-use std::{collections::HashMap, fmt::Display, iter, vec};
+use std::{collections::HashMap, fmt::Display, iter, str, vec};
 
 use either::Either;
 use nom::{AsChar, InputIter};
 
-use crate::{Parameter, SingleExpression};
+use crate::{expand::OwnedChars, Parameter, SingleExpression};
 
 use super::{
-    Expression, IntoRegexCharIter, ParameterIter, SingleExpressionIter,
-    UnknownParameterError,
+    Expression, IntoRegexCharIter, ParameterError, ParameterIter,
+    SingleExpressionIter,
 };
 
 /// Parser of a [Cucumber Expressions][0] [AST] `Element` with [custom][1]
 /// `Parameters` in mind.
 ///
-/// Every [`Parameter`] should be represented by a single [`Regex`] capturing
-/// group.
+/// Usually [`Parameter`] should be represented by a single [`Regex`] capturing
+/// group. In case there are multiple capturing groups, they will be named
+/// like `__{parameter_id}_{group_id}`. This is done to identify multiple
+/// capturing groups related to a single parameter.
 ///
 /// [`Regex`]: regex::Regex
 /// [0]: https://github.com/cucumber/cucumber-expressions#readme
@@ -60,7 +62,10 @@ pub trait Provider<Input> {
 
     /// Value matcher to be used in a [`Regex`].
     ///
-    /// Should be represented by a single [`Regex`] capturing group.
+    /// Usually [`Parameter`] should be represented by a single [`Regex`]
+    /// capturing group. In case there are multiple capturing groups, they will
+    /// be named like `__{parameter_id}_{group_id}`. This is done to identify
+    /// multiple capturing groups related to a single parameter.
     ///
     /// [`Regex`]: regex::Regex
     type Value: InputIter<Item = Self::Item>;
@@ -126,7 +131,7 @@ where
 /// [`IntoRegexCharIter::Iter`] for [`WithCustom`]`<`[`Expression`]`>`.
 type ExpressionWithParsIter<I, P> = iter::Chain<
     iter::Chain<
-        iter::Once<Result<char, UnknownParameterError<I>>>,
+        iter::Once<Result<char, ParameterError<I>>>,
         iter::FlatMap<
             iter::Map<
                 iter::Zip<vec::IntoIter<SingleExpression<I>>, iter::Repeat<P>>,
@@ -140,7 +145,7 @@ type ExpressionWithParsIter<I, P> = iter::Chain<
             ) -> SingleExprWithParsIter<I, P>,
         >,
     >,
-    iter::Once<Result<char, UnknownParameterError<I>>>,
+    iter::Once<Result<char, ParameterError<I>>>,
 >;
 
 impl<Input, Pars> IntoRegexCharIter<Input>
@@ -191,17 +196,69 @@ where
     fn into_regex_char_iter(self) -> Self::Iter {
         use Either::{Left, Right};
 
-        let ok: fn(_) -> _ = |c: <P::Value as InputIter>::Item| Ok(c.as_char());
-        self.parameters.get(&self.element).map_or_else(
-            || Right(self.element.into_regex_char_iter()),
-            |v| {
-                Left(
-                    iter::once(Ok('('))
-                        .chain(v.iter_elements().map(ok))
-                        .chain(iter::once(Ok(')'))),
+        let id = self.element.id;
+
+        match self.parameters.get(&self.element) {
+            None => Right(Left(self.element.into_regex_char_iter())),
+            Some(v) => {
+                // We try to find '(' inside regex. If unsuccessfully, we can be
+                // sure, regex has no groups, so we can skip parsing.
+                let parsed = v
+                    .iter_elements()
+                    .any(|c| c.as_char() == '(')
+                    .then(|| {
+                        let re = v
+                            .iter_elements()
+                            .map(AsChar::as_char)
+                            .collect::<String>();
+                        let hir = regex_syntax::Parser::new()
+                            .parse(&re)
+                            .map_err(|err| (self.element.input, re, err))?;
+                        Ok(regex_hir::has_capture_groups(&hir).then(|| hir))
+                    })
+                    .transpose();
+                let parsed = match parsed {
+                    Ok(hir) => hir.flatten(),
+                    Err((parameter, re, err)) => {
+                        return Left(iter::once(Err(
+                            ParameterError::RenameRegexGroup {
+                                parameter,
+                                re,
+                                err,
+                            },
+                        )));
+                    }
+                };
+
+                parsed.map_or_else(
+                    || {
+                        let ok: fn(_) -> _ =
+                            |c: <P::Value as InputIter>::Item| Ok(c.as_char());
+
+                        Right(Right(Right(
+                            iter::once(Ok('('))
+                                .chain(v.iter_elements().map(ok))
+                                .chain(iter::once(Ok(')'))),
+                        )))
+                    },
+                    |cur_hir| {
+                        let ok: fn(_) -> _ = Ok;
+
+                        let new_hir = regex_hir::rename_groups(cur_hir, id);
+                        Right(Right(Left(
+                            "(?:"
+                                .chars()
+                                .map(ok)
+                                .chain(
+                                    OwnedChars::new(new_hir.to_string())
+                                        .map(ok),
+                                )
+                                .chain(iter::once(Ok(')'))),
+                        )))
+                    },
                 )
-            },
-        )
+            }
+        }
     }
 }
 
@@ -209,26 +266,149 @@ where
 //       https://github.com/rust-lang/rust/issues/63063
 /// [`IntoRegexCharIter::Iter`] for [`WithCustom`]`<`[`Parameter`]`>`.
 type WithParsIter<I, P> = Either<
-    iter::Chain<
-        iter::Chain<
-            iter::Once<Result<char, UnknownParameterError<I>>>,
-            iter::Map<
-                <<P as Provider<I>>::Value as InputIter>::IterElem,
-                fn(
-                    <<P as Provider<I>>::Value as InputIter>::Item,
-                ) -> Result<char, UnknownParameterError<I>>,
+    iter::Once<Result<char, ParameterError<I>>>,
+    Either<
+        ParameterIter<I>,
+        Either<
+            iter::Chain<
+                iter::Chain<
+                    iter::Map<
+                        str::Chars<'static>,
+                        fn(char) -> Result<char, ParameterError<I>>,
+                    >,
+                    iter::Map<
+                        OwnedChars,
+                        fn(char) -> Result<char, ParameterError<I>>,
+                    >,
+                >,
+                iter::Once<Result<char, ParameterError<I>>>,
+            >,
+            iter::Chain<
+                iter::Chain<
+                    iter::Once<Result<char, ParameterError<I>>>,
+                    iter::Map<
+                        <<P as Provider<I>>::Value as InputIter>::IterElem,
+                        fn(
+                            <<P as Provider<I>>::Value as InputIter>::Item,
+                        )
+                            -> Result<char, ParameterError<I>>,
+                    >,
+                >,
+                iter::Once<Result<char, ParameterError<I>>>,
             >,
         >,
-        iter::Once<Result<char, UnknownParameterError<I>>>,
     >,
-    ParameterIter<I>,
 >;
+
+/// Helper methods to work with [`Regex`]es [`Hir`].
+///
+/// [`Hir`]: hir::Hir
+/// [`Regex`]: regex::Regex
+mod regex_hir {
+    use std::mem;
+
+    use regex_syntax::hir;
+
+    /// Checks whether [`Regex`]es [`Hir`] contains capturing groups.
+    ///
+    /// [`Hir`]: hir::Hir
+    /// [`Regex`]: regex::Regex
+    pub(super) fn has_capture_groups(hir: &hir::Hir) -> bool {
+        match hir.kind() {
+            hir::HirKind::Empty
+            | hir::HirKind::Literal(_)
+            | hir::HirKind::Class(_)
+            | hir::HirKind::Anchor(_)
+            | hir::HirKind::WordBoundary(_)
+            | hir::HirKind::Repetition(_)
+            | hir::HirKind::Group(hir::Group {
+                kind: hir::GroupKind::NonCapturing,
+                ..
+            }) => false,
+            hir::HirKind::Group(hir::Group {
+                kind:
+                    hir::GroupKind::CaptureName { .. }
+                    | hir::GroupKind::CaptureIndex(_),
+                ..
+            }) => true,
+            hir::HirKind::Concat(inner) | hir::HirKind::Alternation(inner) => {
+                inner.iter().any(has_capture_groups)
+            }
+        }
+    }
+
+    /// Adds name `__{parameter_id}_{group_id}` to [`Regex`]es [`Hir`] capture
+    /// groups.
+    ///
+    /// [`Hir`]: hir::Hir
+    /// [`Regex`]: regex::Regex
+    pub(super) fn rename_groups(
+        hir: hir::Hir,
+        parameter_id: usize,
+    ) -> hir::Hir {
+        rename_groups_inner(hir, parameter_id, &mut 0)
+    }
+
+    /// Adds name `__{parameter_id}_{group_id}` to [`Regex`]es [`Hir`] capture
+    /// groups.
+    ///
+    /// [`Hir`]: hir::Hir
+    /// [`Regex`]: regex::Regex
+    fn rename_groups_inner(
+        hir: hir::Hir,
+        parameter_id: usize,
+        group_id: &mut usize,
+    ) -> hir::Hir {
+        match hir.into_kind() {
+            hir::HirKind::Empty => hir::Hir::empty(),
+            hir::HirKind::Literal(lit) => hir::Hir::literal(lit),
+            hir::HirKind::Class(cl) => hir::Hir::class(cl),
+            hir::HirKind::Anchor(anc) => hir::Hir::anchor(anc),
+            hir::HirKind::WordBoundary(bound) => hir::Hir::word_boundary(bound),
+            hir::HirKind::Repetition(rep) => hir::Hir::repetition(rep),
+            hir::HirKind::Group(mut group) => {
+                match group.kind {
+                    hir::GroupKind::CaptureIndex(index)
+                    | hir::GroupKind::CaptureName { index, .. } => {
+                        // TODO: Use "{id}" syntax once MSRV bumps above 1.58.
+                        group.kind = hir::GroupKind::CaptureName {
+                            name: format!("__{}_{}", parameter_id, *group_id),
+                            index,
+                        };
+                        *group_id += 1;
+                    }
+                    hir::GroupKind::NonCapturing => {}
+                }
+
+                let inner_hir =
+                    mem::replace(group.hir.as_mut(), hir::Hir::empty());
+                drop(mem::replace(
+                    group.hir.as_mut(),
+                    rename_groups_inner(inner_hir, parameter_id, group_id),
+                ));
+
+                hir::Hir::group(group)
+            }
+            hir::HirKind::Concat(concat) => hir::Hir::concat(
+                concat
+                    .into_iter()
+                    .map(|h| rename_groups_inner(h, parameter_id, group_id))
+                    .collect(),
+            ),
+            hir::HirKind::Alternation(alt) => hir::Hir::alternation(
+                alt.into_iter()
+                    .map(|h| rename_groups_inner(h, parameter_id, group_id))
+                    .collect(),
+            ),
+        }
+    }
+}
 
 #[cfg(test)]
 mod spec {
     use crate::expand::Error;
 
-    use super::{Expression, HashMap, UnknownParameterError};
+    use super::{Expression, HashMap, ParameterError};
 
     #[test]
     fn custom_parameter() {
@@ -238,6 +418,21 @@ mod spec {
             .unwrap_or_else(|e| panic!("failed: {}", e));
 
         assert_eq!(expr.as_str(), "^(custom)$");
+    }
+
+    #[test]
+    fn custom_parameter_with_groups() {
+        let pars = HashMap::from([("custom", "\"(custom)\"|'(custom)'")]);
+        // TODO: Use "{e}" syntax once MSRV bumps above 1.58.
+        let expr =
+            Expression::regex_with_parameters("{custom} {custom}", &pars)
+                .unwrap_or_else(|e| panic!("failed: {}", e));
+
+        assert_eq!(
+            expr.as_str(),
+            "^(?:\"(?P<__0_0>custom)\"|'(?P<__0_1>custom)') \
+              (?:\"(?P<__1_0>custom)\"|'(?P<__1_1>custom)')$",
+        );
     }
 
     #[test]
@@ -256,10 +451,10 @@ mod spec {
 
         match Expression::regex_with_parameters("{custom}", &pars).unwrap_err()
         {
-            Error::Expansion(UnknownParameterError { not_found }) => {
+            Error::Expansion(ParameterError::NotFound(not_found)) => {
                 assert_eq!(*not_found, "custom");
             }
-            e @ (Error::Regex(_) | Error::Parsing(_)) => {
+            e @ (Error::Regex(_) | Error::Parsing(_) | Error::Expansion(_)) => {
                 // TODO: Use "{e}" syntax once MSRV bumps above 1.58.
                 panic!("wrong err: {}", e)
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1533,7 +1533,7 @@ mod spec {
         };
 
         #[test]
-        fn string_parameters_ids() {
+        fn parameters_ids() {
             assert_ast_eq(
                 unwrap_parser(expression(Spanned::new("{string} {string}"))),
                 r#"Expression(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -143,6 +143,7 @@ where
 /// [0]: crate#grammar
 pub fn parameter<'a, Input: 'a>(
     input: Input,
+    id: &mut usize,
 ) -> IResult<Input, Parameter<Input>, Error<Input>>
 where
     Input: Clone
@@ -164,13 +165,13 @@ where
         match inp.iter_elements().next().map(AsChar::as_char) {
             Some('{') => {
                 if let Ok((_, (par, ..))) = peek(tuple((
-                    parameter,
+                    |i| parameter(i, &mut 0),
                     escaped_reserved_chars0(take_while(is_name)),
                     tag("}"),
                 )))(inp.clone())
                 {
                     return Error::NestedParameter(
-                        inp.take(par.0.input_len() + 2),
+                        inp.take(par.input.input_len() + 2),
                     )
                     .failure();
                 }
@@ -203,7 +204,14 @@ where
         fail(input.clone(), opening_brace.clone())
     })(input.clone())?;
 
-    Ok((input, Parameter(par_name)))
+    *id += 1;
+    Ok((
+        input,
+        Parameter {
+            input: par_name,
+            id: *id - 1,
+        },
+    ))
 }
 
 /// Parses an `optional` as defined in the [grammar spec][0].
@@ -291,9 +299,11 @@ where
                     .failure();
             }
             Some('{') => {
-                if let Ok((_, par)) = peek(parameter)(inp.clone()) {
+                if let Ok((_, par)) =
+                    peek(|i| parameter(i, &mut 0))(inp.clone())
+                {
                     return Error::ParameterInOptional(
-                        inp.take(par.0.input_len() + 2),
+                        inp.take(par.input.input_len() + 2),
                     )
                     .failure();
                 }
@@ -507,6 +517,7 @@ where
 /// [0]: crate#grammar
 pub fn single_expression<'a, Input: 'a>(
     input: Input,
+    id: &mut usize,
 ) -> IResult<Input, SingleExpression<Input>, Error<Input>>
 where
     Input: Clone
@@ -528,7 +539,7 @@ where
     alt((
         map(alternation, SingleExpression::Alternation),
         map(optional, SingleExpression::Optional),
-        map(parameter, SingleExpression::Parameter),
+        map(|i| parameter(i, id), SingleExpression::Parameter),
         map(
             verify(
                 escaped_reserved_chars0(take_while(is_without_whitespace)),
@@ -584,7 +595,8 @@ where
     Error<Input>: ParseError<Input>,
     for<'s> &'s str: FindToken<<Input as InputIter>::Item>,
 {
-    map(many0(single_expression), Expression)(input)
+    let mut id = 0;
+    map(many0(move |i| single_expression(i, &mut id)), Expression)(input)
 }
 
 /// Possible parsing errors.
@@ -813,13 +825,16 @@ mod spec {
 
         #[test]
         fn empty() {
-            assert_eq!(**unwrap_parser(parameter(Spanned::new("{}"))), "");
+            assert_eq!(
+                **unwrap_parser(parameter(Spanned::new("{}"), &mut 0)),
+                "",
+            );
         }
 
         #[test]
         fn named() {
             assert_eq!(
-                **unwrap_parser(parameter(Spanned::new("{string}"))),
+                **unwrap_parser(parameter(Spanned::new("{string}"), &mut 0)),
                 "string",
             );
         }
@@ -827,7 +842,10 @@ mod spec {
         #[test]
         fn named_with_spaces() {
             assert_eq!(
-                **unwrap_parser(parameter(Spanned::new("{with space}"))),
+                **unwrap_parser(parameter(
+                    Spanned::new("{with space}"),
+                    &mut 0,
+                )),
                 "with space",
             );
         }
@@ -835,7 +853,7 @@ mod spec {
         #[test]
         fn named_with_escaped() {
             assert_eq!(
-                **unwrap_parser(parameter(Spanned::new("{with \\{}"))),
+                **unwrap_parser(parameter(Spanned::new("{with \\{}"), &mut 0)),
                 "with \\{",
             );
         }
@@ -843,14 +861,17 @@ mod spec {
         #[test]
         fn named_with_closing_paren() {
             assert_eq!(
-                **unwrap_parser(parameter(Spanned::new("{with )}"))),
+                **unwrap_parser(parameter(Spanned::new("{with )}"), &mut 0)),
                 "with )",
             );
         }
 
         #[test]
         fn named_with_emoji() {
-            assert_eq!(**unwrap_parser(parameter(Spanned::new("{🦀}"))), "🦀");
+            assert_eq!(
+                **unwrap_parser(parameter(Spanned::new("{🦀}"), &mut 0)),
+                "🦀",
+            );
         }
 
         #[test]
@@ -858,14 +879,14 @@ mod spec {
             let span = Spanned::new("");
 
             assert_eq!(
-                parameter(span),
+                parameter(span, &mut 0),
                 Err(Err::Error(Error::Other(span, ErrorKind::Tag))),
             );
         }
 
         #[test]
         fn fails_on_escaped_non_reserved() {
-            let err = parameter(Spanned::new("{\\r}")).unwrap_err();
+            let err = parameter(Spanned::new("{\\r}"), &mut 0).unwrap_err();
 
             match err {
                 Err::Failure(Error::EscapedNonReservedCharacter(e)) => {
@@ -886,7 +907,8 @@ mod spec {
                 "{{nest}after}",
                 "{bef{nest}aft}",
             ] {
-                match parameter(Spanned::new(input)).expect_err("error") {
+                match parameter(Spanned::new(input), &mut 0).expect_err("error")
+                {
                     Err::Failure(Error::NestedParameter(e)) => {
                         // TODO: Use "{input}" syntax once MSRV bumps above
                         //       1.58.
@@ -906,7 +928,8 @@ mod spec {
                 "{(nest)after}",
                 "{bef(nest)aft}",
             ] {
-                match parameter(Spanned::new(input)).expect_err("error") {
+                match parameter(Spanned::new(input), &mut 0).expect_err("error")
+                {
                     Err::Failure(Error::OptionalInParameter(e)) => {
                         // TODO: Use "{input}" syntax once MSRV bumps above
                         //       1.58.
@@ -926,7 +949,8 @@ mod spec {
                 ("{{nest}", "{"),
                 ("{l/r}", "/"),
             ] {
-                match parameter(Spanned::new(input)).expect_err("error") {
+                match parameter(Spanned::new(input), &mut 0).expect_err("error")
+                {
                     Err::Failure(Error::UnescapedReservedCharacter(e)) => {
                         // TODO: Use "{input}" syntax once MSRV bumps above
                         //       1.58.
@@ -941,7 +965,8 @@ mod spec {
         #[test]
         fn fails_on_unfinished() {
             for input in ["{", "{name "] {
-                match parameter(Spanned::new(input)).expect_err("error") {
+                match parameter(Spanned::new(input), &mut 0).expect_err("error")
+                {
                     Err::Failure(Error::UnfinishedParameter(e)) => {
                         // TODO: Use "{input}" syntax once MSRV bumps above
                         //       1.58.
@@ -1508,6 +1533,47 @@ mod spec {
         };
 
         #[test]
+        fn string_parameters_ids() {
+            assert_ast_eq(
+                unwrap_parser(expression(Spanned::new("{string} {string}"))),
+                r#"Expression(
+                    [
+                        Parameter(
+                            Parameter {
+                                input: LocatedSpan {
+                                    offset: 1,
+                                    line: 1,
+                                    fragment: "string",
+                                    extra: (),
+                                },
+                                id: 0,
+                            },
+                        ),
+                        Whitespaces(
+                            LocatedSpan {
+                                offset: 8,
+                                line: 1,
+                                fragment: " ",
+                                extra: (),
+                            },
+                        ),
+                        Parameter(
+                            Parameter {
+                                input: LocatedSpan {
+                                    offset: 10,
+                                    line: 1,
+                                    fragment: "string",
+                                    extra: (),
+                                },
+                                id: 1,
+                            },
+                        ),
+                    ],
+                )"#,
+            )
+        }
+
+        #[test]
         fn allows_escaped_optional_parameter_types() {
             assert_ast_eq(
                 unwrap_parser(expression(Spanned::new("\\({int})"))),
@@ -1522,14 +1588,15 @@ mod spec {
                             },
                         ),
                         Parameter(
-                            Parameter(
-                                LocatedSpan {
+                            Parameter {
+                                input: LocatedSpan {
                                     offset: 3,
                                     line: 1,
                                     fragment: "int",
                                     extra: (),
                                 },
-                            ),
+                                id: 0,
+                            },
                         ),
                         Text(
                             LocatedSpan {
@@ -1577,14 +1644,15 @@ mod spec {
                             ),
                         ),
                         Parameter(
-                            Parameter(
-                                LocatedSpan {
+                            Parameter {
+                                input: LocatedSpan {
                                     offset: 4,
                                     line: 1,
                                     fragment: "int",
                                     extra: (),
                                 },
-                            ),
+                                id: 0,
+                            },
                         ),
                         Alternation(
                             Alternation(
@@ -1624,14 +1692,15 @@ mod spec {
                 r#"Expression(
                     [
                         Parameter(
-                            Parameter(
-                                LocatedSpan {
+                            Parameter {
+                                input: LocatedSpan {
                                     offset: 1,
                                     line: 1,
                                     fragment: "int",
                                     extra: (),
                                 },
-                            ),
+                                id: 0,
+                            },
                         ),
                         Alternation(
                             Alternation(
@@ -1942,14 +2011,15 @@ mod spec {
                 r#"Expression(
                     [
                         Parameter(
-                            Parameter(
-                                LocatedSpan {
+                            Parameter {
+                                input: LocatedSpan {
                                     offset: 1,
                                     line: 1,
                                     fragment: "",
                                     extra: (),
                                 },
-                            ),
+                                id: 0,
+                            },
                         ),
                     ],
                 )"#,
@@ -2136,14 +2206,15 @@ mod spec {
                 r#"Expression(
                     [
                         Parameter(
-                            Parameter(
-                                LocatedSpan {
+                            Parameter {
+                                input: LocatedSpan {
                                     offset: 1,
                                     line: 1,
                                     fragment: "int",
                                     extra: (),
                                 },
-                            ),
+                                id: 0,
+                            },
                         ),
                         Whitespaces(
                             LocatedSpan {


### PR DESCRIPTION
Part of #7

## Synopsis

Currently `string` parameter regex group leaves quotes.
 



## Solution

Add `__<parameter_id>_<group_id>` name every parameter regex capture group and handle it as a special case in `cucumber-codegen` crate (https://github.com/cucumber-rs/cucumber/pull/204).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests