### PR TITLE
Fix doctests without `into-regex` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ This crate provides [AST] parser, and [`Regex`] expansion of [Cucumber Expressio
 ```rust
 use cucumber_expressions::Expression;
 
-let re = Expression::regex("I have {int} cucumbers in my belly").unwrap();
-let caps = re.captures("I have 42 cucumbers in my belly").unwrap();
-
-assert_eq!(&caps[0], "I have 42 cucumbers in my belly");
-assert_eq!(&caps[1], "42");
+#[cfg(feature = "into-regex")] {
+    let re = Expression::regex("I have {int} cucumbers in my belly").unwrap();
+    let caps = re.captures("I have 42 cucumbers in my belly").unwrap();
+    
+    assert_eq!(&caps[0], "I have 42 cucumbers in my belly");
+    assert_eq!(&caps[1], "42");
+} 
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ Rust implementation of [Cucumber Expressions].
 This crate provides [AST] parser, and [`Regex`] expansion of [Cucumber Expressions].
 
 ```rust
+# // `Regex` expansion requires `into-regex` feature.
+# #[cfg(feature = "into-regex")] {
 use cucumber_expressions::Expression;
 
-#[cfg(feature = "into-regex")] {
-    let re = Expression::regex("I have {int} cucumbers in my belly").unwrap();
-    let caps = re.captures("I have 42 cucumbers in my belly").unwrap();
-    
-    assert_eq!(&caps[0], "I have 42 cucumbers in my belly");
-    assert_eq!(&caps[1], "42");
-} 
+let re = Expression::regex("I have {int} cucumbers in my belly").unwrap();
+let caps = re.captures("I have 42 cucumbers in my belly").unwrap();
+
+assert_eq!(&caps[0], "I have 42 cucumbers in my belly");
+assert_eq!(&caps[1], "42");
+# }
 ```
 
 


### PR DESCRIPTION
Fixes #10

## Synopsis

#10
 



## Solution

Wrap code into `#[cfg(feature = "into-regex")] { ... }`




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests